### PR TITLE
potential aggro implementation

### DIFF
--- a/assets/scripts/ability.gd
+++ b/assets/scripts/ability.gd
@@ -213,3 +213,6 @@ func digest(unit : Unit, _targets : Array, _selected : Tile, _board : Board):
 func lay_egg(_unit : Unit, _targets : Array, _selected : Tile, _board : Board):
 	pass
 
+func buzz(unit : Unit, _targets : Array, _selected : Tile, _board : Board):
+	print("bzz")
+	unit.aggro = 2

--- a/assets/scripts/globals.gd
+++ b/assets/scripts/globals.gd
@@ -12,7 +12,7 @@ var ability_map = {
 	"slash": make_ability("Slash", 3, Ability.RangeAngle.FULL, Vector2(2, 3), Ability.AoeType.CIRCULAR, 2, Ability.AbilityTarget.ENEMY, Ability.Debuff.NONE),
 	"pinch" : make_ability("Pinch", 100, Ability.RangeAngle.FULL, Vector2(1, 1), Ability.AoeType.CIRCULAR, 1, Ability.AbilityTarget.ENEMY, Ability.Debuff.NONE),
 	"dash_slice" : make_ability("Dash Slice", 2, Ability.RangeAngle.PERPENDICULAR, Vector2(2, 10), Ability.AoeType.LINE, 0, Ability.AbilityTarget.EMPTY, Ability.Debuff.NONE, true),
-	"rave" : make_ability("Crab Rave", 1000, Ability.RangeAngle.FULL, Vector2(0, 0), Ability.AoeType.CIRCULAR, 0, Ability.AbilityTarget.ALLY, Ability.Debuff.NONE),
+	"rave" : make_ability("Crab Rave", 0, Ability.RangeAngle.FULL, Vector2(0, 0), Ability.AoeType.CIRCULAR, 0, Ability.AbilityTarget.ALLY, Ability.Debuff.NONE),
 	"lay_egg" : make_ability("Lay Egg", 0, Ability.RangeAngle.FULL, Vector2(1, 1), Ability.AoeType.CIRCULAR, 0, Ability.AbilityTarget.EMPTY, Ability.Debuff.NONE),
 	"birds_with_arms" : make_ability("Birds With Arms", 4, Ability.RangeAngle.FULL, Vector2(1, 4), Ability.AoeType.LINE, -2, Ability.AbilityTarget.ALL_UNITS, Ability.Debuff.NONE),
 	"retweet" : make_ability("Retweet", 0, Ability.RangeAngle.FULL, Vector2(1, 3), Ability.AoeType.CIRCULAR, 0, Ability.AbilityTarget.ALL_UNITS, Ability.Debuff.NONE),
@@ -39,6 +39,7 @@ var special_abilities = {
 	"lay_egg"   : true,
 	"shell_up"  : true,
 	"shell_out" : true,
+	"buzz" 		: true,
 }
 
 static func make_ability(name, dmg, angle, ability_range, aoe_type, aoe, target, debuff, moves = false) -> Ability:

--- a/assets/scripts/manager.gd
+++ b/assets/scripts/manager.gd
@@ -168,10 +168,10 @@ func closest_unit(origin : Vector2, units : Array) -> Unit:
 		return null
 	var closest = units[0]
 	var diff_vector = origin - units[0].occupied_tile
-	var min_distance = abs(diff_vector.x) + abs(diff_vector.y)
+	var min_distance = abs(diff_vector.x) + abs(diff_vector.y) - closest.aggro
 	for unit in units:
 		diff_vector = origin - unit.occupied_tile
-		var diff = abs(diff_vector.x) + abs(diff_vector.y)
+		var diff = abs(diff_vector.x) + abs(diff_vector.y) - unit.aggro
 		if diff < min_distance:
 			min_distance = diff
 			closest = unit

--- a/assets/scripts/unit.gd
+++ b/assets/scripts/unit.gd
@@ -11,8 +11,8 @@ var hp  : int = 10
 var atk : int = 2
 var def : int = 1
 var mov : int = 2
-
 var og_mov : int = mov
+var aggro : int = 0
 
 var buff   : int
 var debuff : int


### PR DESCRIPTION
My suggest implementation for aggro is a unit stat. If we make enemy units prioritize closer units as a basis for their AI, then aggro will just make units appear closer. When an AI unit looks for the closest unit to itself aggro will act as a distance modifier to "push" itself to the front of the line. 